### PR TITLE
Include submodules in CI build

### DIFF
--- a/.github/workflows/ci-sample.yml
+++ b/.github/workflows/ci-sample.yml
@@ -15,5 +15,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        submodules: true 
     - name: Build
       run: dotnet build samples\Plugin.Maui.Feature.Sample.sln -c Release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,5 +15,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        submodules: true 
     - name: Build
       run: dotnet build src\Plugin.Maui.Feature.sln -c Release

--- a/.github/workflows/release-nuget.yml
+++ b/.github/workflows/release-nuget.yml
@@ -12,6 +12,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true 
       - name: Verify commit exists in origin/main
         run: |
           git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*

--- a/.github/workflows/release-nuget.yml
+++ b/.github/workflows/release-nuget.yml
@@ -14,17 +14,25 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true 
+          
       - name: Verify commit exists in origin/main
         run: |
           git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
           git branch --remote --contains | grep origin/main
+          
       - name: Get version information from tag
         id: get_version
         run: |
           $version="${{github.ref_name}}".TrimStart("v")
           "version-without-v=$version" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          
+     # If your project contains submodule uncomment below and fill with proper name an path
+     # - name: Build dependencies
+     #   run: dotnet build dependencies\Submodule.Solution.Name\src\Submodule.Solution.Name.sln -c Release
+        
       - name: Pack
         run: dotnet pack src\Plugin.Maui.Feature.sln -c Release -p:PackageVersion=${{ steps.get_version.outputs.version-without-v }}
+        
       - name: Push
         run: dotnet nuget push src\Plugin.Maui.Feature\bin\Release\Plugin.Maui.Feature.${{ steps.get_version.outputs.version-without-v }}.nupkg -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGET_API_KEY }}
         env:

--- a/src/Plugin.Maui.Feature/Plugin.Maui.Feature.csproj
+++ b/src/Plugin.Maui.Feature/Plugin.Maui.Feature.csproj
@@ -81,4 +81,27 @@
 		<None Include="..\..\README.md" Pack="true" PackagePath="\"/>
 	</ItemGroup>
 
+	<!-- If your project include submodule dependency uncomment below and fill up with proper names and paths. 
+	     Be careful with ProjectReference property as it might have been already added automatically by your IDE after adding a dependency to this project.
+
+	     Explanation: to make things working, you have to "hide" the submodule references and explicitly copy compilation output (binaries) to NuGet package.
+
+	<ItemGroup>
+		<ProjectReference Include="..\..\dependencies\Submodule.Solution.Name\src\Submodule.Solution.Name\Submodule.Solution.Name.csproj" PrivateAssets="All" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<None Include="..\..\dependencies\Plugin.Maui.Audio\src\Submodule.Solution.Name\bin\$(Configuration)\net8.0-android\*.*"
+              	      Pack="true"
+              	      PackagePath="lib/net8.0-android34.0/" />
+		<None Include="..\..\dependencies\Plugin.Maui.Audio\src\Submodule.Solution.Name\bin\$(Configuration)\net8.0-ios\*.*"
+              	      Pack="true"
+              	      PackagePath="lib/net8.0-ios17.5/" />
+		<None Include="..\..\dependencies\Plugin.Maui.Audio\src\Submodule.Solution.Name\bin\$(Configuration)\net8.0-maccatalyst\*.*"
+              	      Pack="true"
+              	      PackagePath="lib/net8.0-maccatalyst17.5/" />
+		<None Include="..\..\dependencies\Plugin.Maui.Audio\src\Submodule.Solution.Name\bin\$(Configuration)\net8.0-windows10.0.19041.0\*.*"
+              	      Pack="true"
+              	      PackagePath="lib/net8.0-windows10.0.19041/" />
+	</ItemGroup> -->
 </Project>

--- a/src/Plugin.Maui.Feature/Plugin.Maui.Feature.csproj
+++ b/src/Plugin.Maui.Feature/Plugin.Maui.Feature.csproj
@@ -91,16 +91,16 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<None Include="..\..\dependencies\Plugin.Maui.Audio\src\Submodule.Solution.Name\bin\$(Configuration)\net8.0-android\*.*"
+		<None Include="..\..\dependencies\Submodule.Solution.Name\src\Submodule.Solution.Name\bin\$(Configuration)\net8.0-android\*.*"
               	      Pack="true"
               	      PackagePath="lib/net8.0-android34.0/" />
-		<None Include="..\..\dependencies\Plugin.Maui.Audio\src\Submodule.Solution.Name\bin\$(Configuration)\net8.0-ios\*.*"
+		<None Include="..\..\dependencies\Submodule.Solution.Name\src\Submodule.Solution.Name\bin\$(Configuration)\net8.0-ios\*.*"
               	      Pack="true"
               	      PackagePath="lib/net8.0-ios17.5/" />
-		<None Include="..\..\dependencies\Plugin.Maui.Audio\src\Submodule.Solution.Name\bin\$(Configuration)\net8.0-maccatalyst\*.*"
+		<None Include="..\..\dependencies\Submodule.Solution.Name\src\Submodule.Solution.Name\bin\$(Configuration)\net8.0-maccatalyst\*.*"
               	      Pack="true"
               	      PackagePath="lib/net8.0-maccatalyst17.5/" />
-		<None Include="..\..\dependencies\Plugin.Maui.Audio\src\Submodule.Solution.Name\bin\$(Configuration)\net8.0-windows10.0.19041.0\*.*"
+		<None Include="..\..\dependencies\Submodule.Solution.Name\src\Submodule.Solution.Name\bin\$(Configuration)\net8.0-windows10.0.19041.0\*.*"
               	      Pack="true"
               	      PackagePath="lib/net8.0-windows10.0.19041/" />
 	</ItemGroup> -->


### PR DESCRIPTION
It is necessary to explicitly declare using submodels in solution. Otherwise builder goes with the error MSB3202: The project file was not found.